### PR TITLE
Tighten lower bound on `base`

### DIFF
--- a/relapse.cabal
+++ b/relapse.cabal
@@ -17,7 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.RLP
                      , Data.RLP.Types
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , attoparsec >= 0.13.1.0  && < 0.14
                      , bytestring
   default-language:    Haskell2010


### PR DESCRIPTION
With base-4.7 the following compile error occurs; this sets the lower bound accordingly to tell the cabal solver
that `relapse` isn't compatible with base-4.7.

```
Configuring component lib from relapse-0.2.0.0...
Preprocessing library relapse-0.2.0.0...
[1 of 2] Compiling Data.RLP.Types   ( src/Data/RLP/Types.hs, /tmp/matrix-worker/1490054760/dist-newstyle/build/x86_64-linux/ghc-7.8.4/relapse-0.2.0.0/build/Data/RLP/Types.o )

src/Data/RLP/Types.hs:43:18:
    Ambiguous occurrence ‘foldl'’
    It could refer to either ‘Data.Foldable.foldl'’,
                             imported from ‘Data.Foldable’ at src/Data/RLP/Types.hs:12:1-30
                          or ‘Data.List.foldl'’,
                             imported from ‘Data.List’ at src/Data/RLP/Types.hs:14:41-46

src/Data/RLP/Types.hs:86:42: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:102:26: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:102:42: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:117:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:118:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:119:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:136:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:137:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:138:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:139:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:158:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:159:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:160:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:161:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:162:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:183:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:184:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:185:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:186:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:187:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:188:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:211:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:212:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:213:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:214:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:215:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:216:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:217:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:242:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:243:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:244:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:245:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:246:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:247:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:248:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:249:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:276:7: Not in scope: ‘<$>’

src/Data/RLP/Types.hs:277:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:278:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:279:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:280:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:281:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:282:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:283:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:284:7: Not in scope: ‘<*>’

src/Data/RLP/Types.hs:289:62: Not in scope: ‘<$>’

```